### PR TITLE
Fix: Click on separator doesn't trigger onPageChange callback

### DIFF
--- a/src/components/Separator.tsx
+++ b/src/components/Separator.tsx
@@ -26,7 +26,7 @@ export const Separator: FC<SeparatorProps> = ({
   // react hooks
   const { actions, state } = useContext(PaginatorContext);
   const { innerLimit, currentPage } = state;
-  const { setCurrentPage } = actions;
+  const { changePage } = actions;
 
   const pageToJump = useMemo(() => {
     if (separatorPosition === "left") return currentPage - innerLimit;
@@ -42,9 +42,9 @@ export const Separator: FC<SeparatorProps> = ({
     if (isDisabled) return;
 
     if (pageToJump) {
-      setCurrentPage(pageToJump);
+      changePage(pageToJump);
     }
-  }, [pageToJump, isDisabled, setCurrentPage]);
+  }, [pageToJump, isDisabled, changePage]);
 
   return (
     <Flex as="li">


### PR DESCRIPTION
Sorry I have not tested the fix as I was not able to install the updated package from my fork. I looked to the Page component, and found that it uses the `changePage` callback instead of `setCurrentPage`. So I guessed that using `changePage` in Separator component as well will fix the issue.